### PR TITLE
Quick fix for ST broken SSL on Linux

### DIFF
--- a/WordpressGenerateSalts.py
+++ b/WordpressGenerateSalts.py
@@ -4,7 +4,8 @@ import sublime, sublime_plugin, urllib.request
 class WordpressGenerateSaltsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         for cursor in self.view.sel():
-            req = urllib.request.Request('https://api.wordpress.org/secret-key/1.1/salt/')
+            #Linux broken SSL http://sublimetext.userecho.com/topic/50801-bundle-python-ssl-module/
+            req = urllib.request.Request('http://api.wordpress.org/secret-key/1.1/salt/')
             response = urllib.request.urlopen(req)
             salts = response.read()
             salts = salts.decode("utf-8")


### PR DESCRIPTION
Linux users can't easy call https URLs with urllib.
Plese see http://sublimetext.userecho.com/topic/50801-bundle-python-ssl-module/

Sublime Text console show this error:

```
WordpressGenerateSalts.py", line 9, in run
    response = urllib.request.urlopen(req)
  File "./urllib/request.py", line 156, in urlopen
  File "./urllib/request.py", line 469, in open
  File "./urllib/request.py", line 492, in _open
  File "./urllib/request.py", line 447, in _call_chain
  File "./urllib/request.py", line 1310, in unknown_open
urllib.error.URLError: <urlopen error unknown url type: https>
```

Similar problem was faced here https://github.com/Floobits/floobits-sublime/issues/96
And here https://github.com/wbond/sublime_package_control/issues/556

Patch just calls http instead of https.

Not ideal if we are getting our WP salt keys, but i hope the NSA don't mess with our WP installations just for this.
