### PR TITLE
Created with style option to generate PHP DotEnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+###SublimeText###
+
+# cache files for sublime text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# workspace files are user-specific
+*.sublime-workspace
+
+# project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using SublimeText
+*.sublime-project
+
+# sftp configuration file
+sftp-config.json
+
+*.pyc

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,4 @@
 [
     { "keys": ["ctrl+alt+g"], "command": "wordpress_generate_salts" },
+    { "keys": ["ctrl+alt+d"], "command": "wordpress_salts_dot_env" },
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,4 @@
 [
     { "keys": ["ctrl+alt+g"], "command": "wordpress_generate_salts" },
+    { "keys": ["ctrl+alt+d"], "command": "wordpress_salts_dot_env" },
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,4 @@
 [
     { "keys": ["ctrl+alt+g"], "command": "wordpress_generate_salts" },
+    { "keys": ["ctrl+alt+d"], "command": "wordpress_salts_dot_env" },
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -3,4 +3,8 @@
         "caption": "WordPress Generate Salt Keys",
         "command": "wordpress_generate_salts"
     },
+    {
+        "caption": "WordPress Generate Salt Keys DotEnv",
+        "command": "wordpress_salts_dot_env"
+    },
 ]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
-# WordPress Generate Salts
+WordPress Generate Salts
+------------------------
 
-A simple plugin for generating WordPress salt keys in [Sublime Text 3](https://sublimetext.com/3).
+A simple plugin for generating WordPress salt keys in [Sublime Text 3](http://www.sublimetext.com/3).
 
-## Installation
-* Install with Will Bond's [Sublime Package Control](http://wbond.net/sublime_packages/package_control)
-* Install with Git
-    1. `cd Packages`
-    2. `git clone https://github.com/tatemz/WordPress-Generate-Salts.git "WordPress Generate Salts"`
-    3. Use the Sublime Text command pallete or `ctrl+alt+g`
+Turn your keys with `define('FOO', 'KeyRandom');` or style [PHP DotEnv](https://github.com/vlucas/phpdotenv) `FOO = 'KeyRandom'`.
+
+**Installation**
+
+ - Install with Will Bond's [Sublime Package Control](http://wbond.net/sublime_packages/package_control)
+ - Install with Git cd Packages git clone
+ - https://github.com/tatemz/WordPress-Generate-Salts.git
+
+**Usage**
+
+ - To generate define ('..', 'key'):
+   - "WordPress Generate Salts" Use the Sublime Text command pallete or
+   `ctrl+alt+g`
+
+ - To generate stylish PHP DotEnv:
+   - "WordPress Generate Salts DotEnv" Use the Sublime Text command pallete or `ctrl+alt+d`
+
+**You may want to read:**
+
+ - [Secure Your WordPress Config with DotEnv](https://dotdev.co/tutorials/secure-wordpress-config-dotenv/)

--- a/WordpressGenerateSalts.py
+++ b/WordpressGenerateSalts.py
@@ -15,8 +15,8 @@ class WordpressSaltsDotEnvCommand(sublime_plugin.TextCommand):
         for cursor in self.view.sel():
             salts = request_url()
             salts = re.sub(r"\w+\('", '', salts)
-            salts = re.sub(r"',\s+'", '=', salts)
-            salts = re.sub(r"'\);", '', salts)
+            salts = re.sub(r"',\s+", '=', salts)
+            salts = re.sub(r"\);", '', salts)
             self.view.insert(edit, cursor.begin(), salts )
 
 def request_url():

--- a/WordpressGenerateSalts.py
+++ b/WordpressGenerateSalts.py
@@ -1,12 +1,27 @@
-import sublime, sublime_plugin, urllib.request
+import sublime, sublime_plugin, urllib.request, re
+
+#Linux broken SSL http://sublimetext.userecho.com/topic/50801-bundle-python-ssl-module/
+API_URL = "http://api.wordpress.org/secret-key/1.1/salt/"
 
 # Extends TextCommand so that run() receives a View to modify.
 class WordpressGenerateSaltsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         for cursor in self.view.sel():
-            #Linux broken SSL http://sublimetext.userecho.com/topic/50801-bundle-python-ssl-module/
-            req = urllib.request.Request('http://api.wordpress.org/secret-key/1.1/salt/')
-            response = urllib.request.urlopen(req)
-            salts = response.read()
-            salts = salts.decode("utf-8")
+            salts = request_url()
             self.view.insert(edit, cursor.begin(), salts )
+
+class WordpressSaltsDotEnvCommand(sublime_plugin.TextCommand):
+    def  run(self, edit):
+        for cursor in self.view.sel():
+            salts = request_url()
+            salts = re.sub(r"\w+\('", '', salts)
+            salts = re.sub(r"',\s+'", '=', salts)
+            salts = re.sub(r"'\);", '', salts)
+            self.view.insert(edit, cursor.begin(), salts )
+
+def request_url():
+    req = urllib.request.Request(API_URL)
+    response = urllib.request.urlopen(req)
+    salts = response.read()
+    return salts.decode("utf-8")
+


### PR DESCRIPTION
Hello, tatemz!

The long use your plugin, but recently I was using the wordpress PHP DotEnv (https://dotdev.co/tutorials/secure-wordpress-config-dotenv/).

I thought then create a way to generate without define ( '...', 'key').
Leaving only the FOO = BAR_KEY.

What do you think? I'm not an expert in python, develop more in php.
